### PR TITLE
Security Patch: Updating google-github-actions to use Workload Identity Provider

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -13,13 +13,14 @@ jobs:
     outputs:
       image_name: ${{ steps.build.outputs.image_name }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/build
         name: Build image
         id: build
 
   deploy_production:
+
     runs-on: ubuntu-latest
     environment: production
     needs: build
@@ -32,13 +33,19 @@ jobs:
           - "1"
           - "137"
           - "43114"
+    permissions:
+      id-token: write
+      
     steps:
       - uses: actions/checkout@v2
       
       - name: GCP Auth
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@v0.6.0
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_workload_identity_provider }}
+          service_account: ${{ secrets.GCP_service_account }}
+          token_format: 'access_token'
+          
       - name: Get GKE credentials
         uses: google-github-actions/get-gke-credentials@v0.4.0
         with:


### PR DESCRIPTION
Per [Google's recommendation](https://github.com/google-github-actions/auth#auth), the authentication method should be upgraded to Workload Identity Federation:
> "Workload Identity Federation is the recommended approach as it obviates the need to export a long-lived Google Cloud service account key .. We recommend using Workload Identity Federation instead as exporting a **long-lived Service Account Key JSON credential poses a security risk**."

*Note: in addition to the code changes, the GCP account admin will need to follow [these pre-requisite steps](https://github.com/google-github-actions/auth#setup) to configure Workload Identity Provider.

I learned about this potential security issue while working on an [Aave DAO grant](https://docs.google.com/document/d/1QtThIW7iLq9_M2VeF5nW8ks77j3cMyR2CeWLiBuNMv4/edit?usp=sharing) setting up the deployment scripts to write to multiple clouds. My testing ability for this was limited due to the [permission restrictions on forked repos](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), but should be more straightforward for an Aave GCP account owner. 